### PR TITLE
fix: add support of UCAN and add tmp file upload 

### DIFF
--- a/backend/storacha/storacha-bridge.mjs
+++ b/backend/storacha/storacha-bridge.mjs
@@ -127,6 +127,23 @@ export const handlers = {
         currentSpace = space;
         
         console.log(`[storacha] UCAN auth initialized, space: ${space.did()}`);
+      } else {
+        // Email-based authentication (fallback flow)
+        client = await Client.create();
+        
+        if (email && typeof email === 'string' && email.trim() !== '') {
+          const accounts = client.accounts();
+          if (Object.keys(accounts).length === 0) {
+            console.error(`[storacha] Logging in with email: ${email}`);
+            await client.login(email);
+            console.error('[storacha] Check your email to authorize this agent');
+          }
+        }
+        
+        currentSpace = await client.createSpace('rclone-space');
+        await client.setCurrentSpace(spaceDID);
+        
+        console.log(`[storacha] Email auth initialized, space: ${spaceDID}`);
       }
       
       // Load existing w3name keys from disk

--- a/backend/storacha/storacha-bridge.mjs
+++ b/backend/storacha/storacha-bridge.mjs
@@ -3,6 +3,10 @@
 // This script runs as a subprocess and communicates via stdin/stdout JSON
 
 import * as Client from '@storacha/client';
+import { StoreMemory } from '@storacha/client/stores/memory';
+import { parse as parseProofText } from '@storacha/client/proof';
+import { extract as extractDelegation } from '@storacha/client/delegation';
+import * as Signer from '@ucanto/principal/ed25519';
 import * as readline from 'readline';
 import * as dagPB from '@ipld/dag-pb';
 import { UnixFS } from 'ipfs-unixfs';
@@ -97,31 +101,33 @@ const rl = readline.createInterface({
 
 // Handler functions
 export const handlers = {
-  async init({ spaceDID, email }) {
+  async init({ spaceDID, email, privateKey, proofPath }) {
     try {
-      // Create client
-      client = await Client.create();
-      
-      // Login if email provided and not already logged in
-      if (email && typeof email === 'string' && email.trim() !== '') {
-        const accounts = client.accounts();
-        if (Object.keys(accounts).length === 0) {
-          console.error(`[storacha] Logging in with email: ${email}`);
-          await client.login(email);
-          console.error('[storacha] Check your email to authorize this agent');
+      if (privateKey && proofPath) {
+        // UCAN key-based authentication
+        const principal = Signer.parse(privateKey);
+        const store = new StoreMemory();
+        client = await Client.create({ principal, store });
+        
+        // Read and parse the proof file (supports base64 text)
+        const rawBytes = await fs.promises.readFile(proofPath);
+        let proof;
+        if (rawBytes[0] < 0x80 && !rawBytes.includes(0)) {
+          // Looks like text (base64-encoded) — use text parser
+          proof = await parseProofText(rawBytes.toString('utf-8').trim());
         }
+        
+        const space = await client.addSpace(proof);
+        await client.setCurrentSpace(space.did());
+        currentSpace = space;
+        
+        console.log(`[storacha] UCAN auth initialized, space: ${space.did()}`);
       }
-      
-      currentSpace = await client.createSpace('rclone-space');
-      const newSpaceDID = spaceDID;
-      
-      // Set it as the current space
-      await client.setCurrentSpace(newSpaceDID);
       
       // Load existing w3name keys from disk
       await loadAllKeys();
       
-      return { initialized: true, spaceDID: newSpaceDID };
+      return { initialized: true, spaceDID: spaceDID };
     } catch (error) {
       throw new Error(`Init failed: ${error.message}`);
     }

--- a/backend/storacha/storacha-bridge.mjs
+++ b/backend/storacha/storacha-bridge.mjs
@@ -109,12 +109,17 @@ export const handlers = {
         const store = new StoreMemory();
         client = await Client.create({ principal, store });
         
-        // Read and parse the proof file (supports base64 text)
+        // Read and parse the proof file (supports both base64 text and binary CAR)
         const rawBytes = await fs.promises.readFile(proofPath);
         let proof;
         if (rawBytes[0] < 0x80 && !rawBytes.includes(0)) {
           // Looks like text (base64-encoded) — use text parser
           proof = await parseProofText(rawBytes.toString('utf-8').trim());
+        } else {
+          // Binary CAR data — use Delegation.extract
+          const result = await extractDelegation(new Uint8Array(rawBytes));
+          if (!result.ok) throw new Error(`Failed to extract delegation: ${result.error?.message}`);
+          proof = result.ok;
         }
         
         const space = await client.addSpace(proof);

--- a/backend/storacha/storacha-bridge.mjs
+++ b/backend/storacha/storacha-bridge.mjs
@@ -126,7 +126,7 @@ export const handlers = {
         await client.setCurrentSpace(space.did());
         currentSpace = space;
         
-        console.log(`[storacha] UCAN auth initialized, space: ${space.did()}`);
+        console.error(`[storacha] UCAN auth initialized, space: ${space.did()}`);
       } else {
         // Email-based authentication (fallback flow)
         client = await Client.create();
@@ -143,7 +143,7 @@ export const handlers = {
         currentSpace = await client.createSpace('rclone-space');
         await client.setCurrentSpace(spaceDID);
         
-        console.log(`[storacha] Email auth initialized, space: ${spaceDID}`);
+        console.error(`[storacha] Email auth initialized, space: ${spaceDID}`);
       }
       
       // Load existing w3name keys from disk
@@ -155,20 +155,29 @@ export const handlers = {
     }
   },
   
-  async upload({ name, data, size }) {
+  async upload({ name, data, filePath, size }) {
     if (!client) throw new Error('Client not initialized');
     if (!currentSpace) throw new Error('No space selected');
-    
-    // data comes as base64 from Go's JSON encoding of []byte
-    const buffer = Buffer.from(data, 'base64');
+
+    // data comes as filepath from tmp file (for better memory usage)
+    let buffer;
+    if (filePath) {
+      buffer = await fs.promises.readFile(filePath);
+    } else if (data) {
+      buffer = Buffer.from(data, 'base64');
+    } else {
+      throw new Error('Either filePath or data is required');
+    }
+
     const file = new File([buffer], name, { type: 'application/octet-stream' });
     
     const cid = await client.uploadFile(file);
     const cidStr = cid.toString();
-    
-    return { 
+
+    console.error(`[storacha] Upload complete: ${cidStr}`);
+    return {
       cid: cidStr,
-      size: buffer.length 
+      size: buffer.length
     };
   },
   

--- a/backend/storacha/storacha_node.go
+++ b/backend/storacha/storacha_node.go
@@ -463,16 +463,28 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 
 // Put uploads a file
 func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	// Read file data
-	data, err := io.ReadAll(in)
+	// stream to temp file instead of buffering entire file in memory
+	// this decreases memory usage in loading into head, encoding, pipe write and then node also holds it in memory
+	tmpFile, err := os.CreateTemp("", "rclone-storacha-upload-*")
 	if err != nil {
-		return nil, fmt.Errorf("failed to read data: %w", err)
+		return nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	written, err := io.Copy(tmpFile, in)
+	if err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("failed to write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	fs.Logf(f, "Streaming upload: %s (%d bytes via temp file)", src.Remote(), written)
 
 	resp, err := f.node.Call("upload", map[string]interface{}{
-		"name": src.Remote(),
-		"data": data, // Will be base64 encoded by JSON
-		"size": src.Size(),
+		"name":     src.Remote(),
+		"filePath": tmpPath,
+		"size":     written,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upload failed: %w", err)

--- a/backend/storacha/storacha_node.go
+++ b/backend/storacha/storacha_node.go
@@ -21,11 +21,13 @@ import (
 
 // Fs represents a Storacha filesystem backed by Node.js subprocess
 type Fs struct {
-	name     string
-	root     string
-	spaceDID string
-	email    string
-	node     *NodeBridge
+	name       string
+	root       string
+	spaceDID   string
+	email      string
+	privateKey string
+	proofPath  string
+	node       *NodeBridge
 }
 
 // Object represents a file stored in Storacha
@@ -77,7 +79,17 @@ func init() {
 			},
 			{
 				Name:     "email",
-				Help:     "Email for Storacha authentication.",
+				Help:     "Email for Storacha authentication (used when private_key is not set).",
+				Required: false,
+			},
+			{
+				Name:     "private_key",
+				Help:     "Ed25519 private key for UCAN key-based authentication (base64 encoded, starts with Mg...).",
+				Required: false,
+			},
+			{
+				Name:     "proof_path",
+				Help:     "Path to proof.ucan delegation file for UCAN key-based authentication.",
 				Required: false,
 			},
 		},
@@ -199,6 +211,8 @@ func (n *NodeBridge) Close() error {
 func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
 	spaceDID, _ := m.Get("space_did")
 	email, _ := m.Get("email")
+	privateKey, _ := m.Get("private_key")
+	proofPath, _ := m.Get("proof_path")
 
 	if spaceDID == "" {
 		return nil, fmt.Errorf("storacha: space_did is required")
@@ -211,18 +225,41 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	f := &Fs{
-		name:     name,
-		root:     root,
-		spaceDID: spaceDID,
-		email:    email,
-		node:     node,
+		name:       name,
+		root:       root,
+		spaceDID:   spaceDID,
+		email:      email,
+		privateKey: privateKey,
+		proofPath:  proofPath,
+		node:       node,
+	}
+
+	// Build init params based on auth mode
+	initParams := map[string]string{
+		"spaceDID": spaceDID,
+	}
+
+	if privateKey != "" && proofPath != "" {
+		// UCAN key-based authentication
+		absProofPath, err := filepath.Abs(proofPath)
+		if err != nil {
+			node.Close()
+			return nil, fmt.Errorf("failed to resolve proof path: %w", err)
+		}
+		if _, err := os.Stat(absProofPath); err != nil {
+			node.Close()
+			return nil, fmt.Errorf("proof file not found at %s: %w", absProofPath, err)
+		}
+		initParams["privateKey"] = privateKey
+		initParams["proofPath"] = absProofPath
+		fs.Logf(f, "Using UCAN key-based authentication")
+	} else if email != "" {
+		initParams["email"] = email
+		fs.Logf(f, "Using email-based authentication")
 	}
 
 	// Initialize the client
-	resp, err := node.Call("init", map[string]string{
-		"spaceDID": spaceDID,
-		"email":    email,
-	})
+	resp, err := node.Call("init", initParams)
 	if err != nil {
 		node.Close()
 		return nil, fmt.Errorf("failed to initialize: %w", err)
@@ -451,6 +488,8 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 	if err := json.Unmarshal(resp.Result, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse upload result: %w", err)
 	}
+
+	fs.Logf(f, "Uploaded %s -> CID: %s", src.Remote(), result.CID)
 
 	return &Object{
 		fs:      f,


### PR DESCRIPTION
this pr adds:
- Added key based auth using privateKey and ucan proof 
- Support both base64 and binary CAR proof
- replace prev base64 encoded string upload through pipe with tmp file and passing filePath,
  - this way decrease memory usage in pipe, node and go heap from converting from file to binary and then uploading
- fallback for parsing ucan proof and email based authentication